### PR TITLE
Set import/no-unresolved in default (frontend) config to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![ackee|@ackee/eslint-config](assets/ackee_git_fronted_eslint.png)
 
-# [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/AckeeCZ/eslint-config/blob/master/LICENSE) [![CI Status](https://img.shields.io/travis/com/AckeeCZ/eslint-config.svg?style=flat)](https://travis-ci.com/AckeeCZ/@ackee/eslint-config) [![Dependency Status](https://img.shields.io/david/AckeeCZ/eslint-config.svg?style=flat-square)](https://david-dm.org/AckeeCZ/eslint-config)
+# [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/AckeeCZ/eslint-config/blob/master/LICENSE) [![CI Status](https://img.shields.io/travis/com/AckeeCZ/eslint-config.svg?style=flat)](https://travis-ci.com/AckeeCZ/eslint-config) [![Dependency Status](https://img.shields.io/david/AckeeCZ/eslint-config.svg?style=flat-square)](https://david-dm.org/AckeeCZ/eslint-config)
 
 # ESLint config Ackee
 

--- a/backend.js
+++ b/backend.js
@@ -9,12 +9,5 @@ module.exports = {
          */
         // https://eslint.org/docs/rules/no-underscore-dangle
         'no-underscore-dangle': 'off',
-
-        /**
-         * REASON: In case of using custom NODE_PATH (common case for backend) linter doesn't recognize
-         *  the path and complains about unresolved paths.
-         */
-        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-        'import/no-unresolved': 'off',
     },
 };

--- a/index.js
+++ b/index.js
@@ -75,10 +75,10 @@ module.exports = {
         'space-before-function-paren': [
             'error',
             {
-                'anonymous': 'never',
-                'named': 'never',
-                'asyncArrow': 'always'
-            }
+                anonymous: 'never',
+                named: 'never',
+                asyncArrow: 'always',
+            },
         ],
 
         // https://eslint.org/docs/rules/no-console
@@ -147,5 +147,12 @@ module.exports = {
          * REASON: https://ackee.slack.com/archives/C07BZ9K32/p1536067640000100
          */
         'import/prefer-default-export': 'off',
+
+        /**
+         * REASON: In case of using custom NODE_PATH (common case for backend or frontend (create-react-app)) linter doesn't recognize
+         *  the path and complains about unresolved paths.
+         */
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        'import/no-unresolved': 'off',
     },
 };


### PR DESCRIPTION
CRA sets custom `NODE_PATH`, so the console ends up full of false positive reports of missing dependencies. The same issue applies for aliases defined with jsconfig (without `eslint-import-resolver-webpack`).

So I've moved the `'import/no-unresolved': 'off'` rule to default (frontend) config. 