### PR TITLE
Feature/eslint react hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - 8
+    - 12
 deploy:
     provider: npm
     email: ackeedevelopment@gmail.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.0 - 2020-08-31
+
+- Upgrade `eslint-plugin-react-hooks` to `4.x`
+- Remove rule for `react-hooks/exhaustive-deps`
+
 ## 2.2.0 - 2020-07-22
 
 - Merge in rules from v1.x.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 module.exports = {
   extends: ["react-app", "plugin:import/errors"],
   rules: {
-    "react-hooks/exhaustive-deps": "off",
-
     "react/prop-types": ["warn", { ignore: ["styles", "rules"] }],
     "react/no-unused-prop-types": [
       "warn",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-jsx-a11y": "6.x",
         "eslint-plugin-react": "7.x",
-        "eslint-plugin-react-hooks": "^3.0.0"
+        "eslint-plugin-react-hooks": "4.x"
     },
     "scripts": {
         "test": "exit 0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,10 +554,10 @@ eslint-plugin-jsx-a11y@6.x:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-react-hooks@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-3.0.0.tgz#9e80c71846eb68dd29c3b21d832728aa66e5bd35"
-  integrity sha512-EjxTHxjLKIBWFgDJdhKKzLh5q+vjTFrqNZX36uIxWS4OfyXe5DawqPj3U5qeJ1ngLwatjzQnmR0Lz0J0YH3kxw==
+eslint-plugin-react-hooks@4.x:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz#6323fbd5e650e84b2987ba76370523a60f4e7925"
+  integrity sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==
 
 eslint-plugin-react@7.x:
   version "7.19.0"


### PR DESCRIPTION
New version of `eslint-plugin-react-hooks` offers better lint checks than older version. Thanks to this we can get rid of insignificant warnings.

For example:

```
const [data, setData] = React.useState({ title: "Hello friend" });
  React.useEffect(() => {
    setData({ title: 'Hello world!'});
  }, []);
```

```
const [age, setAge] = React.useState(77);
React.useEffect(() => {
    setAge(prevAge => age + 1);
}, []);
```

Are now without warnings..