### PR TITLE
✨ Rename depricated img-has-alt rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = {
     "no-use-before-define": "warn",
 
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/v5.1.1/docs/rules/alt-text.md
-    "jsx-a11y/img-has-alt": "warn",
+    "jsx-a11y/alt-text": "warn",
 
     // https://eslint.org/docs/rules/comma-dangle
     "comma-dangle": [


### PR DESCRIPTION
I was upgrading dependencies on a project, and we are suddenly getting `Definition for rule 'jsx-a11y/img-has-alt' was not found`. 

Apparently it has been renamed according to this: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/releases/tag/v5.0.0

I think we might be dealing with this soon on other projects. Therefore here is my suggestion. 