### PR TITLE
:wrench: Add import/order and arrow-body-style rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,5 +116,24 @@ module.exports = {
      * REASON: https://ackee.slack.com/archives/C07BZ9K32/p1536067640000100
      */
     "import/prefer-default-export": "off",
-  },
+
+    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md
+    "import/order": [
+        "warn",
+        {
+            "newlines-between": "always-and-inside-groups",
+            groups: [
+                "builtin",
+                "external",
+                "internal",
+                ["parent", "sibling"],
+                "index",
+                "object",
+            ],
+        },
+    ],
+
+    // https://eslint.org/docs/rules/arrow-body-style
+    "arrow-body-style": ["warn", "as-needed"],
+    },
 };

--- a/index.js
+++ b/index.js
@@ -123,12 +123,9 @@ module.exports = {
         {
             "newlines-between": "always-and-inside-groups",
             groups: [
-                "builtin",
-                "external",
+                ["builtin", "external"],
                 "internal",
-                ["parent", "sibling"],
-                "index",
-                "object",
+                ["parent", "sibling", "index"],
             ],
         },
     ],


### PR DESCRIPTION
### Updates

- Added `import/order` rule with the following configuration
   - `"newlines-between": "always-and-inside-groups"` -> I am not really sure about this one, because it allows spaces inside the groups but when you try to `--fix` the document it puts a newline between each import. My proposal is to leave it like this and handle the new line deletion when running the `eslint --fix`
   - `groups: [
                "builtin",
                "external",
                "internal",
                ["parent", "sibling"],
                "index",
                "object",
            ],` -> the import groups will be grouped according to the array order and the `["parent", "sibling"]` allows to have the `parent` and `sibling` imports inside one group
    - [docs](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) 
 
- `"arrow-body-style": ["warn", "as-needed"]`
  - [docs](https://eslint.org/docs/rules/arrow-body-style)
- they are both only as `warn` to not destroy existing projects
- if you would like to extend the configuration of either of these rules feel free to comment and I will add it

Closes #24 
